### PR TITLE
Vtk loading

### DIFF
--- a/meshnets/utils/data_loading.py
+++ b/meshnets/utils/data_loading.py
@@ -32,7 +32,8 @@ def load_edge_mesh_pv(
         logging.info('Edge list shape : %s', edge_list.shape)
 
     if get_pressure:
-        pressure = edge_mesh.get_array('p', preference='point')
+        # TODO(victor): decide if array reshape is necessary
+        pressure = edge_mesh.get_array('p', preference='point').reshape(-1, 1)
         if verbose:
             logging.info('Pressure shape : %s', pressure.shape)
 
@@ -85,7 +86,8 @@ def load_edge_mesh_meshio(
         logging.info('Edge list shape : %s', edges.shape)
 
     if get_pressure:
-        pressure = mesh.point_data['p']
+        # same behavior as mesh.points
+        pressure = mesh.point_data['p'].byteswap().newbyteorder('<')
         if verbose:
             logging.info('Pressure shape : %s', pressure.shape)
 

--- a/meshnets/utils/data_loading.py
+++ b/meshnets/utils/data_loading.py
@@ -1,4 +1,4 @@
-"""Load the mesh data"""
+""""Methods for loading mesh data"""
 
 from typing import Tuple
 
@@ -6,12 +6,13 @@ from absl import logging
 import meshio
 import numpy as np
 
-# TODO(victor): modify the loader once a data format has been decided
 
-
-def load_mesh_from_obj(obj_path: str,
+def load_triangle_mesh(obj_path: str,
                        verbose: bool = False) -> Tuple[np.ndarray, np.ndarray]:
-    """Load nodes and cells from a .obj file representing a triangle mesh"""
+    """Load nodes and cells from a mesh file representing a triangle mesh.
+    
+    This method is deprecated and only works for meshes composed of triangle
+    faces only."""
 
     mesh = meshio.read(obj_path)
 
@@ -25,5 +26,4 @@ def load_mesh_from_obj(obj_path: str,
     return nodes, cells
 
 
-# TODO(victor): Load pressure label
 # TODO(victor): Load windspeed tuple

--- a/meshnets/utils/data_loading.py
+++ b/meshnets/utils/data_loading.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 from absl import logging
 import meshio
+from meshio._mesh import Mesh
 import numpy as np
 import pyvista as pv
 
@@ -19,12 +20,19 @@ def load_edge_mesh_pv(
     using pyvista."""
 
     mesh = pv.read(obj_path)
-    # `use_all_points=False` discards duplicates and renumber the nodes
-    # TODO(victor): verify that node pressure array is modified accordingly
-    # WARNING: the remeshing should be done prior on the mesh file, not here
+    # Extract all the internal/external edges of the dataset as PolyData.
+    # This produces a full wireframe representation of the input dataset.
+    # WARNING: `use_all_points=False` discards duplicates and unused nodes,
+    # but remeshing should be done prior on the mesh file, not here
+    # TODO(victor): check if True results in point renumbering
     edge_mesh = mesh.extract_all_edges(use_all_points=True)
 
     nodes = edge_mesh.points
+
+    # Returns the edges as an array with format :
+    # [2, point_id_1, point_id_2, 2, point_id_3, point_id_4, 2, ...]
+    # Reshape it to (number_of_edges, 3) and remove the first column containing
+    # only 2s
     edge_list = edge_mesh.lines.reshape((-1, 3))[:, 1:]
 
     if verbose:
@@ -32,6 +40,8 @@ def load_edge_mesh_pv(
         logging.info('Edge list shape : %s', edge_list.shape)
 
     if get_pressure:
+        # reshape from (number_of_points,) to (number_of_points, 1)
+        # to be consistent with cases of multiple node features
         # TODO(victor): decide if array reshape is necessary
         pressure = edge_mesh.get_array('p', preference='point').reshape(-1, 1)
         if verbose:
@@ -40,6 +50,31 @@ def load_edge_mesh_pv(
         return nodes, edge_list, pressure
     else:
         return nodes, edge_list
+
+
+def edges_from_meshio_mesh(mesh: Mesh) -> np.ndarray:
+    """Produce an array containing all the edges in a meshio Mesh object.
+    
+    This array can include duplicates."""
+
+    edges_list = []
+    for cell in mesh.cells:
+        cell_faces = cell.data
+        shape_vertices_nb = cell_faces.shape[1]
+
+        for i in range(shape_vertices_nb - 1):
+            edges_list.append(cell_faces[:, i:(i + 2)])
+        if shape_vertices_nb > 2:
+            # get the edge between the first and last node of the faces
+            edges_list.append(cell_faces[:, ::(shape_vertices_nb - 1)])
+
+        # a bit easier to read but runs approximately 10 times slower
+        # for i in range(shape_vertices_nb - 1):
+        #     edges_list.append(cell_faces[:, [i, i + 1]])
+        # if shape_vertices_nb > 2:
+        #     edges_list.append(cell_faces[:, [0, -1]])
+
+    return np.concatenate(edges_list, axis=0)
 
 
 def load_edge_mesh_meshio(
@@ -61,25 +96,7 @@ def load_edge_mesh_meshio(
     # TODO: this should probably be avoided at file level
     nodes = mesh.points.byteswap().newbyteorder('<')
 
-    # extract all the edges in the mesh
-    edges_list = []
-    for cell in mesh.cells:
-        cell_faces = cell.data
-        shape_vertices_nb = cell_faces.shape[1]
-
-        for i in range(shape_vertices_nb - 1):
-            edges_list.append(cell_faces[:, i:(i + 2)])
-        if shape_vertices_nb > 2:
-            # get the edge between the first and last node of the faces
-            edges_list.append(cell_faces[:, ::(shape_vertices_nb - 1)])
-
-        # a bit easier to read but runs approximately 10 times slower
-        # for i in range(shape_vertices_nb - 1):
-        #     edges_list.append(cell_faces[:, [i, i + 1]])
-        # if shape_vertices_nb > 2:
-        #     edges_list.append(cell_faces[:, [0, -1]])
-
-    edges = np.concatenate(edges_list, axis=0)
+    edges = edges_from_meshio_mesh(mesh)
 
     if verbose:
         logging.info('Nodes shape : %s', nodes.shape)


### PR DESCRIPTION
I implemented two new loading methods that support meshes with multiple face shapes. They extract the nodes coordinates, the edges in the mesh and optionally the pressure at each node.

I have tested them on both .obj and .vtk files. The differences in behavior are the following:
- pyvista method allows reading of some faulty files (e.g. point_data is not the same length as points), meshio returns an error
- meshio method can return big endian arrays depending on the file it reads (observed on the .vtk files), which is not supported by torch, while pyvista automatically converts the types
- meshio method does not check for duplicated edges in its returning array. However, the data processing part transforms any edge list to a sorted, biderectional edge list with no duplicates. As a result, the two graphs are identical after processing.
- pyvista method seems to be faster than the meshio loop method when the number of points/faces becomes big

Base on these observation and code readability, I would suggest to primarely use pyvista to extract meshes from the data files.