### PR TITLE
Dataset processing

### DIFF
--- a/meshnets/main.py
+++ b/meshnets/main.py
@@ -1,7 +1,7 @@
 """The main file to run our code
 
-Currently, it loads mesh data from a .vtk file, defines a wind vector,
-and creates a Graph object from them
+Currently, it processes mesh data to graph data and creates training
+and testing datasets and dataloaders from the processed '.pt' files.
 """
 
 import os
@@ -9,17 +9,18 @@ from pathlib import Path
 
 from absl import app, flags, logging
 import torch
+from torch.utils.data import random_split
 from torch_geometric.loader import DataLoader
 
 from meshnets.utils import data_processing
-from meshnets.utils.datasets import FromDiskGraphDataset
+from meshnets.utils.datasets import FromDiskDataset
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('raw_data_dir', os.path.join('data', 'vtk'),
                     'Path to the folder containing the raw data files')
 flags.DEFINE_string('processed_data_dir', os.path.join('data', 'pt'),
                     'Path to the folder for the processed data files')
-flags.DEFINE_bool('process_raw', False,
+flags.DEFINE_bool('process_raw', True,
                   'Indicate if the raw data must be processed or not')
 
 # Wind vector associated with the simulations
@@ -28,13 +29,15 @@ WIND_VECTOR = (10, 0, 0)
 
 def main(_):
 
+    torch.manual_seed(21)
+
     logging.info('Process the raw data : %s', FLAGS.process_raw)
     if FLAGS.process_raw:
         for raw_file in os.listdir(FLAGS.raw_data_dir):
 
             raw_file_path = os.path.join(FLAGS.raw_data_dir, raw_file)
             processed_graph = data_processing.mesh_file_to_graph_data(
-                raw_file_path, WIND_VECTOR)
+                raw_file_path, WIND_VECTOR, get_pressure=True, verbose=False)
 
             processed_file = Path(raw_file).with_suffix('.pt')
             processed_file_path = os.path.join(FLAGS.processed_data_dir,
@@ -42,10 +45,21 @@ def main(_):
 
             torch.save(processed_graph, processed_file_path)
 
-    dataset = FromDiskGraphDataset(FLAGS.processed_data_dir)
-    dataloader = DataLoader(dataset, batch_size=5, shuffle=True)
-    for batch in dataloader:
-        logging.info(batch)
+    dataset = FromDiskDataset(FLAGS.processed_data_dir)
+    train_dataset, test_dataset = random_split(dataset, [0.8, 0.2])
+
+    # If label 'y' is absent (e.g. for inference), use `exclude_keys=['y']`
+    train_dataloader = DataLoader(
+        train_dataset,
+        batch_size=3,
+        shuffle=True,
+    )
+    test_dataloader = DataLoader(test_dataset, batch_size=1, shuffle=True)
+
+    for batch in train_dataloader:
+        logging.info('Training batch: %s', batch)
+    for batch in test_dataloader:
+        logging.info('Testing batch: %s', batch)
 
 
 if __name__ == '__main__':

--- a/meshnets/main.py
+++ b/meshnets/main.py
@@ -5,7 +5,6 @@ and testing datasets and dataloaders from the processed '.pt' files.
 """
 
 import os
-from pathlib import Path
 
 from absl import app, flags, logging
 import torch
@@ -16,12 +15,12 @@ from meshnets.utils import data_processing
 from meshnets.utils.datasets import FromDiskDataset
 
 FLAGS = flags.FLAGS
-flags.DEFINE_string('raw_data_dir', os.path.join('data', 'vtk'),
-                    'Path to the folder containing the raw data files')
+flags.DEFINE_string('mesh_data_dir', os.path.join('data', 'vtk'),
+                    'Path to the folder containing the mesh files')
 flags.DEFINE_string('processed_data_dir', os.path.join('data', 'pt'),
                     'Path to the folder for the processed data files')
-flags.DEFINE_bool('process_raw', True,
-                  'Indicate if the raw data must be processed or not')
+flags.DEFINE_bool('process_meshes', True,
+                  'Indicate if the mesh data must be processed or not')
 
 # Wind vector associated with the simulations
 WIND_VECTOR = (10, 0, 0)
@@ -31,19 +30,13 @@ def main(_):
 
     torch.manual_seed(21)
 
-    logging.info('Process the raw data : %s', FLAGS.process_raw)
-    if FLAGS.process_raw:
-        for raw_file in os.listdir(FLAGS.raw_data_dir):
-
-            raw_file_path = os.path.join(FLAGS.raw_data_dir, raw_file)
-            processed_graph = data_processing.mesh_file_to_graph_data(
-                raw_file_path, WIND_VECTOR, get_pressure=True, verbose=False)
-
-            processed_file = Path(raw_file).with_suffix('.pt')
-            processed_file_path = os.path.join(FLAGS.processed_data_dir,
-                                               processed_file)
-
-            torch.save(processed_graph, processed_file_path)
+    logging.info('Process the mesh data : %s', FLAGS.process_meshes)
+    if FLAGS.process_meshes:
+        data_processing.mesh_dataset_to_graph_dataset(FLAGS.mesh_data_dir,
+                                                      FLAGS.processed_data_dir,
+                                                      WIND_VECTOR,
+                                                      get_pressure=True,
+                                                      verbose=False)
 
     dataset = FromDiskDataset(FLAGS.processed_data_dir)
     train_dataset, test_dataset = random_split(dataset, [0.8, 0.2])

--- a/meshnets/main.py
+++ b/meshnets/main.py
@@ -32,11 +32,11 @@ def main(_):
 
     logging.info('Process the mesh data : %s', FLAGS.process_meshes)
     if FLAGS.process_meshes:
-        data_processing.mesh_dataset_to_graph_dataset(FLAGS.mesh_data_dir,
-                                                      FLAGS.processed_data_dir,
-                                                      WIND_VECTOR,
-                                                      get_pressure=True,
-                                                      verbose=False)
+        data_processing.mesh_files_to_graph_files(FLAGS.mesh_data_dir,
+                                                  FLAGS.processed_data_dir,
+                                                  WIND_VECTOR,
+                                                  get_pressure=True,
+                                                  verbose=False)
 
     dataset = FromDiskDataset(FLAGS.processed_data_dir)
     train_dataset, test_dataset = random_split(dataset, [0.8, 0.2])

--- a/meshnets/utils/data_loading.py
+++ b/meshnets/utils/data_loading.py
@@ -17,7 +17,9 @@ def load_edge_mesh_pv(
 ) -> Union[Tuple[np.ndarray, np.ndarray, np.ndarray], Tuple[np.ndarray,
                                                             np.ndarray]]:
     """Extract node coordinates, edges and pressure at nodes from a mesh file
-    using pyvista."""
+    using pyvista.
+    
+    If `get_pressure=False`, the returned pressure will be None."""
 
     mesh = pv.read(obj_path)
 
@@ -49,7 +51,9 @@ def load_edge_mesh_pv(
 
         return nodes, edge_list, pressure
     else:
-        return nodes, edge_list
+        if verbose:
+            logging.info('Pressure is : %s', None)
+        return nodes, edge_list, None
 
 
 def edges_from_meshio_mesh(mesh: Mesh) -> np.ndarray:
@@ -86,7 +90,9 @@ def load_edge_mesh_meshio(
     """Extract node coordinates, edges and pressure at nodes from a mesh file
     using meshio.
     
-    Edges can include duplicates.
+    If `get_pressure=False`, the returned pressure will be None.
+
+    Edges can include duplicates. 
     """
 
     mesh = meshio.read(obj_path)
@@ -115,7 +121,9 @@ def load_edge_mesh_meshio(
 
         return nodes, edges, pressure
     else:
-        return nodes, edges
+        if verbose:
+            logging.info('Pressure is : %s', None)
+        return nodes, edges, None
 
 
 def load_triangle_mesh(obj_path: str,

--- a/meshnets/utils/data_processing.py
+++ b/meshnets/utils/data_processing.py
@@ -142,11 +142,11 @@ def mesh_file_to_graph_data(file_path: str,
     return graph
 
 
-def mesh_dataset_to_graph_dataset(mesh_data_dir: str,
-                                  processed_data_dir: str,
-                                  wind_vector: Tuple[float],
-                                  get_pressure: bool = True,
-                                  verbose: bool = False) -> None:
+def mesh_files_to_graph_files(mesh_data_dir: str,
+                              processed_data_dir: str,
+                              wind_vector: Tuple[float],
+                              get_pressure: bool = True,
+                              verbose: bool = False) -> None:
     """Loop through a directory containing mesh files, produce a
     graph representation of each mesh and save the graph as
     a `.pt` file in the processed data directory."""

--- a/meshnets/utils/data_processing.py
+++ b/meshnets/utils/data_processing.py
@@ -1,6 +1,7 @@
 """Process and format the mesh data for our model"""
 
 from typing import Optional
+from typing import Tuple
 
 from absl import logging
 import numpy as np
@@ -103,13 +104,14 @@ def triangle_mesh_to_graph(node_coordinates: np.ndarray,
     return graph
 
 
-def mesh_file_to_graph_data(file_path, wind_vector, verbose=False):
+def mesh_file_to_graph_data(file_path: str,
+                            wind_vector: Tuple[float],
+                            get_pressure: bool = False,
+                            verbose: bool = False) -> Data:
     if verbose:
         logging.info('Loading the mesh data from %s', file_path)
-    mesh = data_loading.load_edge_mesh_pv(file_path,
-                                          get_pressure=True,
-                                          verbose=False)
-    nodes, edges, pressure = mesh[0], mesh[1], mesh[2]
+    nodes, edges, pressure = data_loading.load_edge_mesh_pv(
+        file_path, get_pressure=get_pressure, verbose=verbose)
 
     # node features for each node are the wind vector
     node_features = np.tile(wind_vector, (len(nodes), 1))

--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -5,7 +5,7 @@ import torch
 from torch_geometric.data import Dataset
 
 
-class FromDiskGraphDataset(Dataset):
+class FromDiskDataset(Dataset):
     """Reads a dataset from a given directory.
 
     The examples are stored in `data_dir` as .pt files. The .pt

--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -1,0 +1,52 @@
+"""File containing dataset classes"""
+import os
+
+import torch
+from torch_geometric.data import Dataset
+
+
+class FromDiskGraphDataset(Dataset):
+    """Reads a dataset from a given directory.
+
+    The examples are stored in `data_dir` as .pt files. The .pt
+    extension is what is commonly used to save pytorch objects such as
+    tensors, graphs, models, etc. To save an pytorch object we can use
+    ``torch.save(obj, 'path.pt')``. And then, to load it back into
+    memory we can use ``torch.load('path.pt')``.
+
+    A possible directory could look like this:
+
+    data_dir/
+        training_example_0.pt
+        training_example_1.pt
+        training_example_0.pt
+        training_example_1.pt
+
+    Note that the files do not have to be named like this.
+
+    """
+
+    def __init__(self, data_dir):
+        super().__init__(None, None, None)
+        self.root_dir = data_dir
+        self.files = sorted(os.listdir(data_dir))
+
+    def len(self):
+        return len(self.files)
+
+    def get(self, idx):
+        """The get is simply a method to retrieve an element from the
+        dataset. The only thing that exists in RAM at this point are
+        the paths to the examples. Later, this Dataset class is
+        wrapped by pytorch DataLoaders. These dataloaders will be
+        responsible for batching the data and feeding the batches to
+        the model.
+
+        Example:
+            >>> dataset = FromDiskDataset('data_dir')
+            >>> dataloader = DataLoader(dataset, batch_size=32)
+            >>> for batch in dataloader:
+            >>>     x, y = batch, batch.y
+        """
+        data_path = os.path.join(self.root_dir, self.files[idx])
+        return torch.load(data_path)


### PR DESCRIPTION
This PR includes the processing of multiple '.vtk' files to graph '.pt' files. The single file processing pipeline has been moved from main.py to a data_processing.py method. There is also a new dataset class to create a dataset from disk data that was taken from the inductiva-ml-codebase.

In the current main file, we iterate over the raw data directory, save the processed data, and then use the processed files to create torch_geometric datasets and dataloaders. 

Additionally, data loading with `get_pressure=False` now returns `None` as pressure to better integrate in the pipeline.