### PR TITLE
improved modularity of dataset classes and num_label_features method

### DIFF
--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -1,11 +1,12 @@
-"""File containing dataset classes"""
+"""File containing dataset classes."""
 import os
 
+import numpy as np
 import torch
-from torch_geometric.data import Dataset
+from torch_geometric.data import Data, Dataset
 
 
-class FromDiskDataset(Dataset):
+class FromDiskDataset(torch.utils.data.Dataset):
     """Reads a dataset from a given directory.
 
     The examples are stored in `data_dir` as .pt files. The .pt
@@ -27,14 +28,14 @@ class FromDiskDataset(Dataset):
     """
 
     def __init__(self, data_dir):
-        super().__init__(None, None, None)
+        super().__init__()
         self.root_dir = data_dir
         self.files = sorted(os.listdir(data_dir))
 
-    def len(self):
+    def __len__(self):
         return len(self.files)
 
-    def get(self, idx):
+    def __getitem__(self, idx):
         """The get is simply a method to retrieve an element from the
         dataset. The only thing that exists in RAM at this point are
         the paths to the examples. Later, this Dataset class is
@@ -50,3 +51,50 @@ class FromDiskDataset(Dataset):
         """
         data_path = os.path.join(self.root_dir, self.files[idx])
         return torch.load(data_path)
+
+
+class FromDiskGeoDataset(Dataset):
+    """Reads a torch_geometric dataset from a given directory.
+    
+    This class inherits from torch_geometric Dataset and implements its
+    abstract methods `len` and `get` from the FromDiskDataset class.
+    This offers acces to the torch_geometric Dataset attributes when the .pt
+    files retrieved from disk are torch_geometric Data.
+
+    It also offer a new property called 'num_label_features' following
+    the implementation of 'num_node_features' and 'num_edge_features'
+    in torch_geometric Dataset.
+    """
+
+    def __init__(self, data_dir, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dataset = FromDiskDataset(data_dir=data_dir)
+
+    def len(self) -> int:
+        """Returns the number of graphs stored in the dataset.
+        
+        This is the number of files in the dataset from disk."""
+        return len(self.dataset)
+
+    def get(self, idx: int) -> Data:
+        """Gets the data object at index :obj:`idx`.
+        
+        This is the data object at index :obj:`idx` in the dataset from disk."""
+        return self.dataset[idx]
+
+    @property
+    def num_label_features(self) -> int:
+        """Return the number of features per label in the dataset."""
+        # Following torch_geometric.data.Dataset implementation
+        data = self[0]
+        # Do not fill cache for `InMemoryDataset`:
+        if hasattr(self, '_data_list') and self._data_list is not None:
+            self._data_list[0] = None
+        data = data[0] if isinstance(data, tuple) else data
+        if hasattr(data, 'y'):
+            # Following torch_geometric.data.storage.BaseStorage implementation
+            if 'y' in data and isinstance(data.y, (torch.Tensor, np.ndarray)):
+                return 1 if data.y.ndim == 1 else data.y.shape[-1]
+            return 0
+        raise AttributeError(f"'{data.__class__.__name__}' object has no "
+                             f"attribute 'y'")


### PR DESCRIPTION
This PR separate the FromDiskDataset class from torch_geometric. This makes the FromDiskClass a generic torch Dataset class for any type of data.

It then defines FromDiskGeoDataset which inherits from the torch_geometric Dataset and implements the len() and get() methods using a FromDiskDataset attribute. This class also implements a new num_label_features method following torch_geometric's implementation of similar methods.

Let me know if you think the added modularity is worth it or if I should fuse back the two classes together.