### PR TITLE
changed geometric data passing in model

### DIFF
--- a/meshnets/modules/decoder.py
+++ b/meshnets/modules/decoder.py
@@ -1,7 +1,6 @@
 """"Define the GraphDecoder class."""
 
 import torch
-from torch_geometric.data import Batch
 
 from meshnets.modules.mlp import MLP
 
@@ -21,10 +20,10 @@ class GraphDecoder(torch.nn.Module):
         decoder_widths = (num_mlp_layers + 1) * [latent_size] + [output_size]
         self.node_decoder = MLP(decoder_widths)
 
-    def forward(self, graph: Batch) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Decode the latent node features of a batch of graphs
         to output node features.
         
         Return the output Tensor."""
 
-        return self.node_decoder(graph.x)
+        return self.node_decoder(x)

--- a/meshnets/modules/encoder.py
+++ b/meshnets/modules/encoder.py
@@ -1,7 +1,8 @@
 """"Define the GraphEncoder class."""
 
+from typing import Tuple
+
 import torch
-from torch_geometric.data import Batch
 
 from meshnets.modules.mlp import MLP
 
@@ -27,13 +28,14 @@ class GraphEncoder(torch.nn.Module):
                               ] + (num_mlp_layers + 1) * [latent_size]
         self.edge_encoder = MLP(edge_encoder_widths, layer_norm=True)
 
-    def forward(self, graph: Batch) -> Batch:
-        """Encode the node and edge features of a batch of graphs
-        by applying the corresponding MLP encoder to each feature.
+    def forward(self, x: torch.Tensor,
+                edge_attr: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Encode the node and edge features of graphs by applying
+        the corresponding MLP encoder to each feature.
         
-        Return the enconded batch."""
+        Return the encoded features."""
 
-        graph.x = self.node_encoder(graph.x)
-        graph.edge_attr = self.edge_encoder(graph.edge_attr)
+        x = self.node_encoder(x)
+        edge_attr = self.edge_encoder(edge_attr)
 
-        return graph
+        return x, edge_attr

--- a/meshnets/modules/model.py
+++ b/meshnets/modules/model.py
@@ -35,8 +35,10 @@ class MeshGraphNet(torch.nn.Module):
         """Apply the MeshGraphNet to a batch of graphs
         and return the prediction tensor."""
 
-        latent_data = self.encoder(data)
-        latent_data = self.processor(latent_data)
-        prediction = self.decoder(latent_data)
+        x, edge_index, edge_attr = data.x, data.edge_index, data.edge_attr
+
+        x, edge_attr = self.encoder(x, edge_attr)
+        x, edge_attr = self.processor(x, edge_index, edge_attr)
+        prediction = self.decoder(x)
 
         return prediction


### PR DESCRIPTION
This PR changes the argument passing throughout the whole MGN model.

Except for the main model, the forward methods do not receive `Batch` anymore, but the detailed arguments s.a. `x` (the node features), `edge_attr` (the edge features), `edge_index` (the list of edge indices). 

This seems to be closer to standard practice, and avoids accidents resulting from `Data`/`Batch` being unmutable.

Additional implication is: replacement of `Sequential` by `ModuleList` in the processor, because sequential can only receive single arguments.

Small unrelated addition: added `__repr__` method in the Processor layer class because the default `MessagePassing` method does not detail inner modules.