### PR TITLE
input norm moved to model

### DIFF
--- a/meshnets/modules/lightning_wrapper.py
+++ b/meshnets/modules/lightning_wrapper.py
@@ -29,6 +29,7 @@ class MGNLightningWrapper(pl.LightningModule):
         self.model = model(**model_args)
         self.learning_rate = learning_rate
 
+    @torch.no_grad()
     def normalize_labels(self, y: torch.Tensor) -> torch.Tensor:
         """Normalize the labels in a batch.
         

--- a/meshnets/modules/model.py
+++ b/meshnets/modules/model.py
@@ -39,6 +39,7 @@ class MeshGraphNet(torch.nn.Module):
 
         self.decoder = GraphDecoder(output_size, latent_size, num_mlp_layers)
 
+    @torch.no_grad()
     def normalize_input(
             self, x: torch.Tensor,
             edge_attr: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/meshnets/modules/model.py
+++ b/meshnets/modules/model.py
@@ -1,5 +1,7 @@
 """Define the main MeshGraphNet model"""
 
+from typing import Tuple
+
 import torch
 from torch_geometric.data import Batch
 
@@ -18,10 +20,16 @@ class MeshGraphNet(torch.nn.Module):
     outputs features at each node from the processed latent node features."""
 
     def __init__(self, node_features_size, edge_features_size, output_size,
-                 latent_size, num_mlp_layers, message_passing_steps):
-        """Initialize the GraphEncoder, GraphProcessor and GraphDecoder
-        of the MeshGraphNet."""
+                 latent_size, num_mlp_layers, message_passing_steps, x_mean,
+                 x_std, edge_attr_mean, edge_attr_std):
+        """Initialize the input statistics, GraphEncoder, GraphProcessor
+        and GraphDecoder of the MeshGraphNet."""
         super().__init__()
+
+        self.x_mean = x_mean
+        self.x_std = x_std
+        self.edge_attr_mean = edge_attr_mean
+        self.edge_attr_std = edge_attr_std
 
         self.encoder = GraphEncoder(node_features_size, edge_features_size,
                                     latent_size, num_mlp_layers)
@@ -31,11 +39,29 @@ class MeshGraphNet(torch.nn.Module):
 
         self.decoder = GraphDecoder(output_size, latent_size, num_mlp_layers)
 
+    def normalize_input(
+            self, x: torch.Tensor,
+            edge_attr: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Normalize the graph features.
+        
+        The node and edge features are normalized according to the mean and std
+        given to the model."""
+
+        # Send the stats to the same device as the data and normalize
+        x = (x - self.x_mean.to(x.device)) / self.x_std.to(x.device)
+
+        edge_attr = (edge_attr - self.edge_attr_mean.to(
+            edge_attr.device)) / self.edge_attr_std.to(edge_attr.device)
+
+        return x, edge_attr
+
     def forward(self, data: Batch) -> torch.Tensor:
         """Apply the MeshGraphNet to a batch of graphs
         and return the prediction tensor."""
 
         x, edge_index, edge_attr = data.x, data.edge_index, data.edge_attr
+
+        x, edge_attr = self.normalize_input(x, edge_attr)
 
         x, edge_attr = self.encoder(x, edge_attr)
         x, edge_attr = self.processor(x, edge_index, edge_attr)

--- a/meshnets/utils/model_training.py
+++ b/meshnets/utils/model_training.py
@@ -87,7 +87,12 @@ def train_model(config, experiment_config, train_dataset, validation_dataset):
         latent_size=latent_size,
         num_mlp_layers=num_mlp_layers,
         message_passing_steps=message_passing_steps,
-        data_stats=train_stats,
+        x_mean=train_stats['x_mean'],
+        x_std=train_stats['x_std'],
+        edge_attr_mean=train_stats['edge_attr_mean'],
+        edge_attr_std=train_stats['edge_attr_std'],
+        y_mean=train_stats['y_mean'],
+        y_std=train_stats['y_std'],
         learning_rate=learning_rate)
     num_params = sum(p.numel() for p in lightning_wrapper.model.parameters())
 


### PR DESCRIPTION
This PR moves the input normalisation into the model instead of the lightning wrapper.

This makes the model independent of the wrapper to run inference.

Label normalisation is kept in the wrapper, the model is agnostic to the labels.