### PR TITLE
Better dataset splitting

### DIFF
--- a/meshnets/eval.py
+++ b/meshnets/eval.py
@@ -1,5 +1,4 @@
 """The main file for model evaluation."""
-
 import os
 
 from absl import app
@@ -22,8 +21,6 @@ flags.DEFINE_string('data_dir', os.path.join('data', 'dataset'),
 
 flags.DEFINE_float('train_split', 0.9,
                    'The fraction of the dataset used for traing.')
-flags.DEFINE_float('validation_split', 0.1,
-                   'The fraction of the dataset used for validation.')
 
 flags.DEFINE_integer('batch_size', 8, 'The batch size for evaluation.')
 
@@ -43,8 +40,10 @@ def main(_):
         torch.manual_seed(random_seed)
 
     dataset = FromDiskGeometricDataset(FLAGS.data_dir)
+    size_dataset = len(dataset)
+    num_training = int(FLAGS.train_split * size_dataset)
     _, validation_dataset = random_split(
-        dataset, [FLAGS.train_split, FLAGS.validation_split])
+        dataset, [num_training, size_dataset - num_training])
 
     validation_dataloader = DataLoader(validation_dataset,
                                        batch_size=FLAGS.batch_size,

--- a/meshnets/visualize.py
+++ b/meshnets/visualize.py
@@ -23,8 +23,6 @@ flags.DEFINE_string('data_dir', os.path.join('data', 'dataset'),
 
 flags.DEFINE_float('train_split', 0.9,
                    'The fraction of the dataset used for traing.')
-flags.DEFINE_float('validation_split', 0.1,
-                   'The fraction of the dataset used for validation.')
 
 flags.DEFINE_string('tracking_uri', None,
                     'The tracking URI for the MLFlow experiments.')
@@ -50,8 +48,10 @@ def main(_):
         torch.manual_seed(random_seed)
 
     dataset = FromDiskGeometricDataset(FLAGS.data_dir)
+    size_dataset = len(dataset)
+    num_training = int(FLAGS.train_split * size_dataset)
     _, validation_dataset = random_split(
-        dataset, [FLAGS.train_split, FLAGS.validation_split])
+        dataset, [num_training, size_dataset - num_training])
 
     wrapper = model_loading.load_model_from_mlflow(FLAGS.tracking_uri,
                                                    FLAGS.run_id,

--- a/meshnets/visualize.py
+++ b/meshnets/visualize.py
@@ -1,5 +1,4 @@
 """The main file for result visualization."""
-
 import os
 
 from absl import app


### PR DESCRIPTION
This pull request removes an unnecessary and and bug prone flag (FLAGS.validation_split) in the visualization script.
Now we just need to give the dataset the split ratio.

**Note**: I think it may be even better to remove this all-together and just give the script a path to validation data which is, by default split on disc.