### PR TITLE
Changes to the generation data procedure

### DIFF
--- a/data_generation/download_tasks.py
+++ b/data_generation/download_tasks.py
@@ -5,6 +5,7 @@ from absl import logging
 
 import os
 import json
+import warnings
 
 import inductiva
 
@@ -12,12 +13,6 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string("path_to_sim_info", None,
                     "The path to the simulation json info files.")
-
-flags.DEFINE_string(
-    "download_dir", None,
-    "Where to download the data. If None, the data is not downloaded.")
-
-flags.mark_flag_as_required("download_dir")
 
 
 def main(_):
@@ -38,11 +33,14 @@ def main(_):
     logging.info("Tasks successfully completed: %s",
                  len(tasks_successfully_completed))
 
+    download_dir = os.path.dirname(FLAGS.path_to_sim_info)
     for task in tasks_successfully_completed:
-        save_path = f"{FLAGS.download_dir}_{task.id}"
+        save_path = os.path.join(download_dir, task.id)
         output = task.get_output()
         if not os.path.exists(save_path):
             os.makedirs(save_path)
+            warnings.warn(
+                f"Download task {task.id} for which no directory existed")
         output.get_object_pressure_field(
             save_path=os.path.join(save_path, "pressure_field.vtk"))
 

--- a/data_generation/submit_tasks.py
+++ b/data_generation/submit_tasks.py
@@ -36,12 +36,12 @@ def simulate_wind_tunnel_scenario(obj_path, flow_velocity, x_geometry,
     scenario = inductiva.fluids.WindTunnel(flow_velocity=flow_velocity,
                                            domain=domain_geometry)
 
-    task_id = scenario.simulate(object_path=obj_path,
-                                num_iterations=num_iterations,
-                                resolution="low",
-                                run_async=True,
-                                machine_group=machine_group)
-    return task_id
+    task = scenario.simulate(object_path=obj_path,
+                             num_iterations=num_iterations,
+                             resolution="low",
+                             run_async=True,
+                             machine_group=machine_group)
+    return task
 
 
 def main(_):
@@ -62,7 +62,7 @@ def main(_):
         disk_size_gb=FLAGS.disk_size_gb)
     machine_group.start()
 
-    obj_path_and_task_ids = [
+    obj_path_and_tasks = [
         (object_path,
          simulate_wind_tunnel_scenario(object_path, flow_velocity, x_geometry,
                                        y_geometry, z_geometry,
@@ -73,18 +73,17 @@ def main(_):
     # Copy the object files to a folder with path
     # FLAGS.output_dataset/task_id. This keeps track of the obj file
     # for the given file.
-    for object_path, taks_id in obj_path_and_task_ids:
-        os.makedirs(os.path.join(FLAGS.output_dataset, taks_id.id))
-        shutil.copy(
-            object_path,
-            os.path.join(FLAGS.output_dataset, taks_id.id, "object.obj"))
+    for object_path, task in obj_path_and_tasks:
+        os.makedirs(os.path.join(FLAGS.output_dataset, task.id))
+        shutil.copy(object_path,
+                    os.path.join(FLAGS.output_dataset, task.id, "object.obj"))
 
     # Make a json with the task ids and the machine group name.
     with open(os.path.join(FLAGS.output_dataset, "sim_info.json"),
               "w",
               encoding="utf-8") as f:
         dict_to_save = {
-            "task_ids": [task_id.id for _, task_id in obj_path_and_task_ids],
+            "task_ids": [task.id for _, task in obj_path_and_tasks],
             "machine_group": machine_group.name
         }
         json.dump(dict_to_save, f)


### PR DESCRIPTION
## Description

This pull request changes the data generation procedure in order to keep track of the original `.obj` files that originate the pressure field.

Now, when running the `submit_tasks.py` script, we will give it a directory with `.obj` files with the structure:

```
.
└── input_dataset/
    ├── file_1.obj
    └── file_2.obj
```

And it will create a file structure like this:

```
.
└── output_dataset/
    ├── 123123/
    │   └── object.obj
    └── 534857/
        └── object.obj
```

Then we run the script `download_tasks.py` to download the simulation data to the corresponding folders. Obtaining something like this:

```
.
└── output_dataset/
    ├── 123123/
    │   ├── object.obj
    │   └── pressure_field.vtk
    └── 534857/
        ├── object.obj
        └── pressure_field.vtk
```

## Files changed

1. `submit_tasks.py`: was changed in order to copy the obj file from the input dataset to the output dataset. It sores the object inside a folder whose name is its corresponding task_id;
2. `download_tasks.py`: was changed to download the `.vtk` files to the folder with its task id.
3. `monitor_tasks.py` required **no** changes
