### PR TITLE
Removing the data processing from the dataset

### DIFF
--- a/meshnets/__init__.py
+++ b/meshnets/__init__.py
@@ -1,4 +1,3 @@
 """Init"""
-from . import datatypes
 from . import modules
 from . import utils

--- a/meshnets/process.py
+++ b/meshnets/process.py
@@ -1,24 +1,61 @@
 """The main file for data processing."""
-
 import os
+import warnings
 
 from absl import app
 from absl import flags
 
-from meshnets.utils.datasets import FromDiskGeometricDataset
+import torch
+
+import meshnets.utils.data_processing as data_processing
 
 FLAGS = flags.FLAGS
 
-# Path flags
 flags.DEFINE_string('data_dir', os.path.join('data', 'dataset'),
                     'Path to the folder containing the mesh files.')
 
+# TODO: This will be deprecated soon as we will start training with
+# varying wind speeds. At the moment this is here just for support
+# while not metadata is added to the dataset containing the wind
+# speed.
+WIND_VECTOR = [30., 0, 0]
+
 
 def main(_):
-    """Process mesh data files to encoded graph data files."""
+    """
+    Converts the .vtk files in the data_dir to graph data and saves them
+    as .pt files.
 
-    dataset = FromDiskGeometricDataset(FLAGS.data_dir)
-    dataset.convert_mesh_to_graph_data()
+    Assumes that the data_dir contains folders with the following structure:
+
+    data_dir
+        - 199834348
+            - pressure_field.vtk
+        - 129383949
+            - pressure_field.vtk
+
+    """
+    sim_folders = [
+        os.path.join(FLAGS.data_dir, f) for f in os.listdir(FLAGS.data_dir)
+    ]
+
+    # Remove folders that do not contain a .vtk file.
+    for folder in sim_folders:
+        if not os.path.exists(os.path.join(folder, 'pressure_field.vtk')):
+            warnings.warn(f'{folder} does not contain a .vtk file.')
+            sim_folders.remove(folder)
+
+    # Convert the .vtk files to graph data.
+    for folder in sim_folders:
+        vtk_file_path = os.path.join(folder, 'pressure_field.vtk')
+        graph_data = data_processing.mesh_file_to_graph_data(vtk_file_path,
+                                                             WIND_VECTOR,
+                                                             load_pressure=True)
+
+        # TODO: Will add suport here for interpolation to the original
+        # mesh in a future pull request.
+
+        torch.save(graph_data, os.path.join(folder, 'pressure_field.pt'))
 
 
 if __name__ == '__main__':

--- a/meshnets/process.py
+++ b/meshnets/process.py
@@ -7,7 +7,7 @@ from absl import flags
 
 import torch
 
-import meshnets.utils.data_processing as data_processing
+from meshnets.utils import data_processing
 
 FLAGS = flags.FLAGS
 

--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -63,31 +63,6 @@ class FromDiskGeometricDataset(Dataset):
         self.mesh_file_name = mesh_file_name
         self.graph_file_name = graph_file_name
 
-    def convert_mesh_to_graph_data(self) -> None:
-        """Create graph files from the mesh files in the data directory.
-        
-        This method saves each graph file in the same sample directory as
-        its corresponding mesh file. The same file name is used."""
-
-        for i in self.indices():
-            mesh_file_path = self.get_mesh_path(i)
-
-            processed_graph = data_processing.mesh_file_to_graph_data(
-                mesh_file_path, WIND_VECTOR, load_pressure=True)
-
-            processed_file_path = os.path.join(self.get_sample_path(i),
-                                               self.graph_file_name)
-
-            torch.save(processed_graph, processed_file_path)
-
-    def remove_files(self, file_name_to_delete: str) -> None:
-        """Remove the required file in each sample directory."""
-
-        for i in range(self.len()):
-            file_path_to_delete = os.path.join(self.get_sample_path(i),
-                                               file_name_to_delete)
-            os.remove(file_path_to_delete)
-
     def len(self) -> int:
         """Return the number of samples in the dataset."""
         return len(self.samples)

--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -6,8 +6,6 @@ import numpy as np
 import torch
 from torch_geometric.data import Data, Dataset
 
-from meshnets.utils import data_processing
-
 # TODO(victor): the wind vector should be
 # obtained individually for each mesh
 WIND_VECTOR = (10, 0, 0)


### PR DESCRIPTION
This removes the data processing from the dataset class. It also removes an unused method `remove_files` from the dataset class.

I think it was not very intuitive to do the processing like this:

```
dataset = FromDiskDataset(path to dataset)
dataset.convert_mesh_to_graph_data()
```

And only then use the dataset in the training scripts. Now we must first process the data and only then can we use the dataset class.

The dataset class should be used for machine learning data pipelines and not for pre-processing purposes.
