### PR TITLE
Added mesh interpolation to the process script

### DIFF
--- a/meshnets/process.py
+++ b/meshnets/process.py
@@ -15,6 +15,16 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('data_dir', os.path.join('data', 'dataset'),
                     'Path to the folder containing the mesh files.')
 
+flags.DEFINE_string('original_pressure_field_name', 'pressure_field.vtk',
+                    'Name of the original pressure field.')
+flags.DEFINE_string('interpolated_pressure_field_name',
+                    'pressure_field_interpolated.vtk',
+                    'Name of the interpolated pressure field.')
+flags.DEFINE_string('original_mesh_name', 'object.obj',
+                    'Name of the original mesh.')
+flags.DEFINE_string('torch_graph_name', 'pressure_field.pt',
+                    'Name of the torch graph.')
+
 flags.DEFINE_float('tolerance', 1.5, 'Tolerance for the mesh sampling.')
 
 # TODO: This will be deprecated soon as we will start training with
@@ -44,14 +54,16 @@ def main(_):
 
     # Remove folders that do not contain a .vtk file.
     for folder in sim_folders:
-        if not os.path.exists(os.path.join(folder, 'pressure_field.vtk')):
+        if not os.path.exists(
+                os.path.join(folder, FLAGS.original_pressure_field_name)):
             warnings.warn(f'{folder} does not contain a .vtk file.')
             sim_folders.remove(folder)
 
     # Convert the .vtk files to graph data.
     for folder in sim_folders:
-        openfoam_mesh_path = os.path.join(folder, 'pressure_field.vtk')
-        original_mesh_path = os.path.join(folder, 'object.obj')
+        openfoam_mesh_path = os.path.join(folder,
+                                          FLAGS.original_pressure_field_name)
+        original_mesh_path = os.path.join(folder, FLAGS.original_mesh_name)
 
         openfoam_mesh = pv.read(openfoam_mesh_path)
         original_mesh = pv.read(original_mesh_path)
@@ -59,13 +71,13 @@ def main(_):
         interpolated_mesh = original_mesh.sample(openfoam_mesh,
                                                  tolerance=FLAGS.tolerance)
         interpolated_mesh_path = os.path.join(
-            folder, 'pressure_field_interpolated.vtk')
+            folder, FLAGS.interpolated_pressure_field_name)
         interpolated_mesh.save(interpolated_mesh_path)
 
         graph_data = data_processing.mesh_file_to_graph_data(
             interpolated_mesh_path, WIND_VECTOR, load_pressure=True)
 
-        torch.save(graph_data, os.path.join(folder, 'pressure_field.pt'))
+        torch.save(graph_data, os.path.join(folder, FLAGS.torch_graph_name))
 
 
 if __name__ == '__main__':

--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -29,10 +29,6 @@ class FromDiskGeometricDataset(Dataset):
             mesh.vtk
             graph.pt
 
-    Note that the directory, file names, and file extensions can be different.
-    `process_data` allows to produce the graph files upon instantiating the 
-    dataset class from a folder containing only the mesh files.
-
     This class inherits from torch_geometric Dataset and implements its
     abstract methods `len` and `get`. This offers access to the torch_geometric
     Dataset attributes when the .pt files retrieved from disk are


### PR DESCRIPTION
This pull request adds interpolation back to the original mesh to the `process.py` script.

**Note**: It also removes a bit of the dataset docstring that I missed in my last pull request.

## Visualizations

OpenFOAM mesh             |  Interpolation to original mesh
:-------------------------:|:-------------------------:
![Screenshot from 2023-10-03 11-33-11](https://github.com/inductiva/meshnets/assets/33664950/834ac324-419e-4e7c-8674-bce63d1ba235) |  ![Screenshot from 2023-10-03 11-33-35](https://github.com/inductiva/meshnets/assets/33664950/db76edb1-23dc-4fc5-992e-ced580e45627)

OpenFOAM mesh             |  Interpolation to original mesh
:-------------------------:|:-------------------------:
![Screenshot from 2023-10-03 11-35-02](https://github.com/inductiva/meshnets/assets/33664950/ff354719-bb25-4d2e-9032-c9cd2ea1892d)|   ![Screenshot from 2023-10-03 11-35-20](https://github.com/inductiva/meshnets/assets/33664950/78334d27-4e15-4249-8054-29c6ade4149d)