### PR TITLE
Filter out folders that do not a .pt file

### DIFF
--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -48,14 +48,24 @@ class FromDiskGeometricDataset(Dataset):
         super().__init__(*args, **kwargs)
 
         self.root_dir = data_dir
+
+        self.mesh_file_name = mesh_file_name
+        self.graph_file_name = graph_file_name
+
         samples = [
             sample for sample in os.listdir(data_dir)
             if os.path.isdir(os.path.join(self.root_dir, sample))
         ]
-        self.samples = sorted(samples)
 
-        self.mesh_file_name = mesh_file_name
-        self.graph_file_name = graph_file_name
+        # Filter out samples that do not have a `.pt` file.
+        for sample in samples:
+            graph_path = os.path.join(self.root_dir, sample,
+                                      self.graph_file_name)
+            if not os.path.isfile(graph_path):
+                warnings.warn(f"Sample '{sample}' does not have a graph file.")
+                samples.remove(sample)
+
+        self.samples = sorted(samples)
 
     def len(self) -> int:
         """Return the number of samples in the dataset."""

--- a/meshnets/utils/datasets.py
+++ b/meshnets/utils/datasets.py
@@ -92,9 +92,6 @@ class FromDiskGeometricDataset(Dataset):
         sample_path = self.get_sample_path(idx)
         graph_path = os.path.join(sample_path, self.graph_file_name)
 
-        if not os.path.isfile(graph_path):
-            warnings.warn(f"File '{graph_path}' does not exist.")
-
         return graph_path
 
     def get(self, idx: int) -> Data:


### PR DESCRIPTION
## Motivation

Sometimes our datasets contain simulation folders that do not have a torch graph. This is usually due to the tasks corresponding to that simulation having failed. The way the dataset was implemented before raised an error when trying to access those non-existing files:

```python
    def get(self, idx: int) -> Data:
        """Get an element from the dataset at the given index.
        
        The only things that exist in RAM at this point are the paths 
        to the samples. This method loads and returns the sample from disk."""

        graph_path = self.get_graph_path(idx)
        return torch.load(graph_path)
```

But, the way this was implemented, it could be the case that `get_graph_path` was returning a non-existing path

```python
    def get_graph_path(self, idx: int) -> str:
        """Get the path to the graph file at the given index."""

        sample_path = self.get_sample_path(idx)
        graph_path = os.path.join(sample_path, self.graph_file_name)

        if not os.path.isfile(graph_path):
            warnings.warn(f"File '{graph_path}' does not exist.")

        return graph_path
```

This pull request filters and warns the user immediately in the `__init__` method if there are folders with no graphs.

**Note**: This is not a replacement for making sure that our datasets have all the intended simulations. But, while we work on that front, this was added to prevent training scripts from crashing. Moreover, since a warning is being raised it is fine that we filter empty folders since it will always be apparent to the user that their data has problems

## Testing

To test this I ran it on a test dataset with just 10 examples, one of which consists of an empty  folder:

![image](https://github.com/inductiva/meshnets/assets/33664950/f8c417d2-0b90-41e4-88c4-1665f007b5c3)

Iterating over the dataset yields the 9 non-empty examples:

![image](https://github.com/inductiva/meshnets/assets/33664950/e95ff350-ebaf-4d8b-8a0e-46e2c01f5e67)


