### PR TITLE
Adding flow velocities

### DIFF
--- a/data_generation/submit_tasks.py
+++ b/data_generation/submit_tasks.py
@@ -6,13 +6,20 @@ import os
 import shutil
 import json
 
+import random
+
 import inductiva
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string("input_dataset", None, "Path to the dataset of objects.")
 
-flags.DEFINE_list("flow_velocity", [30, 0, 0], "Flow velocity in.")
+flags.DEFINE_list("flow_velocity_range_x", [30, 50],
+                  "Range of flow velocity in the x-direction.")
+flags.DEFINE_list("flow_velocity_range_y", [30, 50],
+                  "Range of flow velocity in the y-direction.")
+flags.DEFINE_list("flow_velocity_range_z", [30, 50],
+                  "Range of flow velocity in the z-direction.")
 flags.DEFINE_list("x_geometry", [-5, 20], "X geometry of the domain.")
 flags.DEFINE_list("y_geometry", [-5, 5], "Y geometry of the domain.")
 flags.DEFINE_list("z_geometry", [-2, 10], "Z geometry of the domain.")
@@ -50,7 +57,10 @@ def main(_):
         for path in os.listdir(FLAGS.input_dataset)
     ]
 
-    flow_velocity = list(map(float, FLAGS.flow_velocity))
+    flow_velocity_range_x = list(map(float, FLAGS.flow_velocity_range_x))
+    flow_velocity_range_y = list(map(float, FLAGS.flow_velocity_range_y))
+    flow_velocity_range_z = list(map(float, FLAGS.flow_velocity_range_z))
+
     x_geometry = list(map(float, FLAGS.x_geometry))
     y_geometry = list(map(float, FLAGS.y_geometry))
     z_geometry = list(map(float, FLAGS.z_geometry))
@@ -62,28 +72,42 @@ def main(_):
         disk_size_gb=FLAGS.disk_size_gb)
     machine_group.start()
 
-    obj_path_and_tasks = [
-        (object_path,
-         simulate_wind_tunnel_scenario(object_path, flow_velocity, x_geometry,
-                                       y_geometry, z_geometry,
-                                       FLAGS.num_iterations, machine_group))
-        for object_path in object_paths
-    ]
+    obj_task_velocitiies = []
+    for object_path in object_paths:
+        flow_velocity_x = random.uniform(*flow_velocity_range_x)
+        flow_velocity_y = random.uniform(*flow_velocity_range_y)
+        flow_velocity_z = random.uniform(*flow_velocity_range_z)
+
+        task = simulate_wind_tunnel_scenario(
+            object_path, [flow_velocity_x, flow_velocity_y, flow_velocity_z],
+            x_geometry, y_geometry, z_geometry, FLAGS.num_iterations,
+            machine_group)
+
+        obj_task_velocitiies.append(
+            (object_path, task,
+             [flow_velocity_x, flow_velocity_y, flow_velocity_z]))
 
     # Copy the object files to a folder with path
     # FLAGS.output_dataset/task_id. This keeps track of the obj file
     # for the given file.
-    for object_path, task in obj_path_and_tasks:
+    for object_path, task, flow_velocity in obj_task_velocitiies:
         os.makedirs(os.path.join(FLAGS.output_dataset, task.id))
         shutil.copy(object_path,
                     os.path.join(FLAGS.output_dataset, task.id, "object.obj"))
+
+        # Save the flow velocity with the simulation.
+        with open(os.path.join(FLAGS.output_dataset, task.id,
+                               "flow_velocity.json"),
+                  "w",
+                  encoding="utf-8") as f:
+            json.dump(flow_velocity, f)
 
     # Make a json with the task ids and the machine group name.
     with open(os.path.join(FLAGS.output_dataset, "sim_info.json"),
               "w",
               encoding="utf-8") as f:
         dict_to_save = {
-            "task_ids": [task.id for _, task in obj_path_and_tasks],
+            "task_ids": [task.id for _, task, _ in obj_task_velocitiies],
             "machine_group": machine_group.name
         }
         json.dump(dict_to_save, f)


### PR DESCRIPTION
## Adding Wind Speed Range and Saving Velocity Information

### Description
This pull request adds functionality to specify and utilize wind speed ranges for simulations in the wind tunnel scenario. It also includes saving the velocity information along with the generated obj files for each simulation.

### Changes Made
- Added new command line flags `flow_velocity_range_x`, `flow_velocity_range_y`, and `flow_velocity_range_z` to specify the range of wind speed in the x, y, and z directions respectively.
- Modified the code to generate random wind speeds within the specified ranges for each simulation.
- Updated the `simulate_wind_tunnel_scenario` function to accept the wind speed as a list [x, y, z].
- Saved the wind speed values along with the obj files by creating a separate file named "velocity.txt" in each simulation folder.

### Testing
I ran the code, the tasks were properly submitted and the velocities were being saved properly
