### PR TITLE
Repackage the scripts

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -5,10 +5,8 @@ import os
 from absl import app
 from absl import flags
 import torch
-from torch.utils.data import random_split
 
-from meshnets.utils import model_training
-from meshnets.utils.datasets import FromDiskGeometricDataset
+import meshnets
 
 TUNING_RUN = False
 FLAGS = flags.FLAGS
@@ -70,8 +68,8 @@ def main(_):
         torch.manual_seed(random_seed)
 
     dataset_name = os.path.basename(FLAGS.data_dir)
-    dataset = FromDiskGeometricDataset(FLAGS.data_dir)
-    train_dataset, validation_dataset = random_split(
+    dataset = meshnets.utils.datasets.FromDiskGeometricDataset(FLAGS.data_dir)
+    train_dataset, validation_dataset = torch.utils.data.random_split(
         dataset, [FLAGS.train_split, FLAGS.validation_split])
 
     val_datasets_names = [dataset_name]
@@ -79,8 +77,8 @@ def main(_):
 
     for val_data_dir in FLAGS.val_data_dirs:
         dataset_name = os.path.basename(val_data_dir)
-        dataset = FromDiskGeometricDataset(val_data_dir)
-        _, validation_dataset = random_split(
+        dataset = meshnets.utils.datasets.FromDiskGeometricDataset(val_data_dir)
+        _, validation_dataset = torch.utils.data.random_split(
             dataset, [FLAGS.train_split, FLAGS.validation_split])
 
         val_datasets_names.append(dataset_name)
@@ -105,11 +103,12 @@ def main(_):
         'save_top_k': FLAGS.save_top_k,
     }
 
-    model_training.train_model(config,
-                               experiment_config,
-                               train_dataset,
-                               validation_datasets_names=val_datasets_names,
-                               validation_datasets=val_datasets)
+    meshnets.utils.model_training.train_model(
+        config,
+        experiment_config,
+        train_dataset,
+        validation_datasets_names=val_datasets_names,
+        validation_datasets=val_datasets)
 
 
 if __name__ == '__main__':

--- a/scripts/tune.py
+++ b/scripts/tune.py
@@ -8,10 +8,8 @@ import mlflow
 import ray
 from ray import tune
 import torch
-from torch.utils.data import random_split
 
-from meshnets.utils import model_training
-from meshnets.utils.datasets import FromDiskGeometricDataset
+import meshnets
 
 TUNING_RUN = True
 FLAGS = flags.FLAGS
@@ -75,8 +73,8 @@ def main(_):
         torch.manual_seed(random_seed)
 
     dataset_name = os.path.basename(FLAGS.data_dir)
-    dataset = FromDiskGeometricDataset(FLAGS.data_dir)
-    train_dataset, validation_dataset = random_split(
+    dataset = meshnets.utils.datasets.FromDiskGeometricDataset(FLAGS.data_dir)
+    train_dataset, validation_dataset = torch.utils.data.random_split(
         dataset, [FLAGS.train_split, FLAGS.validation_split])
 
     val_datasets_names = [dataset_name]
@@ -84,8 +82,8 @@ def main(_):
 
     for val_data_dir in FLAGS.val_data_dirs:
         dataset_name = os.path.basename(val_data_dir)
-        dataset = FromDiskGeometricDataset(val_data_dir)
-        _, validation_dataset = random_split(
+        dataset = meshnets.utils.datasets.FromDiskGeometricDataset(val_data_dir)
+        _, validation_dataset = torch.utils.data.random_split(
             dataset, [FLAGS.train_split, FLAGS.validation_split])
 
         val_datasets_names.append(dataset_name)
@@ -128,7 +126,7 @@ def main(_):
     mlflow.create_experiment(FLAGS.experiment_name)
 
     trainable = tune.with_parameters(
-        model_training.train_model,
+        meshnets.utils.model_training.train_model,
         experiment_config=experiment_config,
         train_dataset=train_dataset,
         validation_datasets_names=val_datasets_names,

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -6,11 +6,8 @@ from absl import flags
 import numpy as np
 import pyvista as pv
 import torch
-from torch.utils.data import random_split
 
-from meshnets.utils.datasets import FromDiskGeometricDataset
-from meshnets.utils import data_visualization
-from meshnets.utils import model_loading
+import meshnets
 
 FLAGS = flags.FLAGS
 
@@ -46,15 +43,14 @@ def main(_):
     if random_seed is not None:
         torch.manual_seed(random_seed)
 
-    dataset = FromDiskGeometricDataset(FLAGS.data_dir)
+    dataset = meshnets.utils.datasets.FromDiskGeometricDataset(FLAGS.data_dir)
     size_dataset = len(dataset)
     num_training = int(FLAGS.train_split * size_dataset)
-    _, validation_dataset = random_split(
+    _, validation_dataset = torch.utils.data.random_split(
         dataset, [num_training, size_dataset - num_training])
 
-    wrapper = model_loading.load_model_from_mlflow(FLAGS.tracking_uri,
-                                                   FLAGS.run_id,
-                                                   FLAGS.checkpoint)
+    wrapper = meshnets.utils.model_loading.load_model_from_mlflow(
+        FLAGS.tracking_uri, FLAGS.run_id, FLAGS.checkpoint)
 
     sample_idx = np.random.choice(validation_dataset.indices)
 
@@ -74,29 +70,32 @@ def main(_):
     if FLAGS.start_xvfb:
         pv.start_xvfb()
 
-    data_visualization.plot_mesh_comparison(mesh_path,
-                                            groundtruth,
-                                            prediction,
-                                            clim=None,
-                                            rotate_z=180,
-                                            off_screen=False,
-                                            screenshot=FLAGS.output_file_path)
+    meshnets.utils.data_visualization.plot_mesh_comparison(
+        mesh_path,
+        groundtruth,
+        prediction,
+        clim=None,
+        rotate_z=180,
+        off_screen=False,
+        screenshot=FLAGS.output_file_path)
 
-    data_visualization.plot_relative_error(mesh_path,
-                                           groundtruth,
-                                           prediction,
-                                           clim=None,
-                                           rotate_z=180,
-                                           off_screen=False,
-                                           screenshot=FLAGS.output_file_path)
+    meshnets.utils.data_visualization.plot_relative_error(
+        mesh_path,
+        groundtruth,
+        prediction,
+        clim=None,
+        rotate_z=180,
+        off_screen=False,
+        screenshot=FLAGS.output_file_path)
 
-    data_visualization.plot_relative_error(mesh_path,
-                                           groundtruth,
-                                           prediction,
-                                           clim=[0, 1],
-                                           rotate_z=180,
-                                           off_screen=False,
-                                           screenshot=FLAGS.output_file_path)
+    meshnets.utils.data_visualization.plot_relative_error(
+        mesh_path,
+        groundtruth,
+        prediction,
+        clim=[0, 1],
+        rotate_z=180,
+        off_screen=False,
+        screenshot=FLAGS.output_file_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request:

1. Moves the python scripts `eval.py`, `train.py`, `tune.py`, `visualize.py` to the `scripts/` folder.
2. Changes a few imports, mainly `meshnets` imports, to be more compliant with the python style guides
