### PR TITLE
Update and remove deprecated ray code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,6 @@ torch-scatter
 torch_geometric
 pytorch_lightning==1.6.*
 ray[default]
-ray_lightning
 mlflow
 google-cloud-storage
 gputil
-inductiva
-inductiva[fluids_extra]

--- a/scripts/tune.py
+++ b/scripts/tune.py
@@ -121,13 +121,13 @@ def main(_):
     mlflow.create_experiment(FLAGS.experiment_name)
 
     # Alocate resources per trial.
-    resources_per_worker = {
+    resources_per_trial = {
         'cpu': FLAGS.num_cpus_per_worker,
         'gpu': FLAGS.num_gpus_per_worker
     }
 
     scaling_config = ScalingConfig(num_workers=FLAGS.num_workers_ray,
-                                   resources_per_worker=resources_per_worker)
+                                   resources_per_worker=resources_per_trial)
 
     trainer = TorchTrainer(meshnets.utils.model_training.train_model,
                            scaling_config=scaling_config,


### PR DESCRIPTION
This pull request removes the usage of the `ray_lightning` library that was deprecated earlier this year.
I made only changes to the `train` function in order to remove these dependencies this **was not** meant to be a refactoring of the `train` function itself. That might come later.

## Testing

To test these changes I quickly adapted the scripts `train.py` and `tune.py`. Everything is working fine but I have not commited those files because they have un-merged changes in other pull open requests and I do not want to have to solve conflicts later. As soon as these pull requests are merged I will commit the necessary changes to the scripts.

## More information

https://docs.ray.io/en/latest/train/getting-started-pytorch-lightning.html
https://docs.ray.io/en/latest/train/examples/lightning/lightning_cola_advanced.html#lightning-advanced-example
