### PR TITLE
Adds a collat_fn

### DIFF
--- a/meshnets/data_processing/__init__.py
+++ b/meshnets/data_processing/__init__.py
@@ -1,2 +1,3 @@
 """Init file"""
 from . import data_mappers
+from . import torch_utils

--- a/meshnets/data_processing/torch_utils.py
+++ b/meshnets/data_processing/torch_utils.py
@@ -3,11 +3,11 @@ import torch
 import torch_geometric
 
 
-def collate_fn(examples,
-               x_key='node_features',
-               edge_index_key='edges',
-               edge_attr_key='edge_features',
-               y_key='wind_pressures'):
+def dict_to_geometric_data(examples,
+                           x_key='node_features',
+                           edge_index_key='edges',
+                           edge_attr_key='edge_features',
+                           y_key='wind_pressures'):
     """Collate function for pytorch dataloader
 
     Args:
@@ -20,6 +20,9 @@ def collate_fn(examples,
         features. Defaults to 'edge_features'.
         y_key (str, optional): Key for the target values. Defaults to
         'wind_pressures'.
+
+    Returns:
+        torch_geometric.data.Batch: Batch object containing the
 
     This assumes examples have the structure:
     {
@@ -37,6 +40,18 @@ def collate_fn(examples,
 
     The function wraps the examples in a torch_geometric.data.Data
     object and returns a torch_geometric.data.Batch object.
+
+    python code usage:
+    >>> from torch_geometric.data import DataLoader
+    >>> from torch_geometric.data import Batch
+    >>> from torch_utils import dict_to_geometric_data
+    >>> dataset[0].keys()
+    dict_keys(['node_features', 'edges', 'edge_features', 'wind_pressures'])
+    >>> loader = DataLoader(dataset, batch_size=32,
+    ...                     collate_fn=dict_to_geometric_data_collate)
+    >>> for batch in loader:
+    ...     print(batch)
+    
 
     """
     graphs = [

--- a/meshnets/data_processing/torch_utils.py
+++ b/meshnets/data_processing/torch_utils.py
@@ -22,7 +22,7 @@ def dict_to_geometric_data(examples,
         'wind_pressures'.
 
     Returns:
-        torch_geometric.data.Batch: Batch object containing the
+        torch_geometric.data.Batch: Batch object containing the graphs
 
     This assumes examples have the structure:
     {
@@ -51,7 +51,6 @@ def dict_to_geometric_data(examples,
     ...                     collate_fn=dict_to_geometric_data_collate)
     >>> for batch in loader:
     ...     print(batch)
-    
 
     """
     graphs = [

--- a/meshnets/data_processing/torch_utils.py
+++ b/meshnets/data_processing/torch_utils.py
@@ -8,10 +8,42 @@ def collate_fn(examples,
                edge_index_key='edges',
                edge_attr_key='edge_features',
                y_key='wind_pressures'):
+    """Collate function for pytorch dataloader
+
+    Args:
+        examples (list): List of examples from the dataset
+        x_key (str, optional): Key for the node features. Defaults to
+        'node_features'.
+        edge_index_key (str, optional): Key for the edge
+        indices. Defaults to 'edges'.
+        edge_attr_key (str, optional): Key for the edge
+        features. Defaults to 'edge_features'.
+        y_key (str, optional): Key for the target values. Defaults to
+        'wind_pressures'.
+
+    This assumes examples have the structure:
+    {
+        x_key: torch.tensor,
+        edge_index_key: torch.tensor,
+        edge_attr_key: torch.tensor,
+        y_key: torch.tensor
+    }
+
+    where the tensors have the following shapes:
+    x_key: (num_nodes, num_node_features)
+    edge_index_key: (num_edges, 2)
+    edge_attr_key: (num_edges, num_edge_features)
+    y_key: (num_nodes, num_target_values)
+
+    The function wraps the examples in a torch_geometric.data.Data
+    object and returns a torch_geometric.data.Batch object.
+
+    """
     graphs = [
-        torch_geometric.data.Data(x=torch.tensor(e[x_key]),
-                                  edge_index=torch.tensor(e[edge_index_key]).T,
-                                  edge_attr=torch.tensor(e[edge_attr_key]),
-                                  y=torch.tensor(e[y_key])) for e in examples
+        torch_geometric.data.Data(
+            x=torch.tensor(example[x_key]),
+            edge_index=torch.tensor(example[edge_index_key]).T,
+            edge_attr=torch.tensor(example[edge_attr_key]),
+            y=torch.tensor(example[y_key])) for example in examples
     ]
     return torch_geometric.data.Batch.from_data_list(graphs)

--- a/meshnets/data_processing/torch_utils.py
+++ b/meshnets/data_processing/torch_utils.py
@@ -1,0 +1,17 @@
+"""Utility functions for usage with pytorch"""
+import torch
+import torch_geometric
+
+
+def collate_fn(examples,
+               x_key='node_features',
+               edge_index_key='edges',
+               edge_attr_key='edge_features',
+               y_key='wind_pressures'):
+    graphs = [
+        torch_geometric.data.Data(x=torch.tensor(e[x_key]),
+                                  edge_index=torch.tensor(e[edge_index_key]).T,
+                                  edge_attr=torch.tensor(e[edge_attr_key]),
+                                  y=torch.tensor(e[y_key])) for e in examples
+    ]
+    return torch_geometric.data.Batch.from_data_list(graphs)


### PR DESCRIPTION
This pull request adds a collat_fn. This will be important for integrating the hugging face datasets with the torch dataloaders:

```python
>>> import meshnets
>>> import datasets
>>> import torch
>>> import meshnets
>>> dataset = datasets.load_dataset('....', version='....', split='train')
>>> dataset = dataset.map(lambda x: meshnets.data_processing.data_mappers.to_undirected(x)).\
                      map(meshnets.data_processing.data_mappers.make_edge_features).\
                      map(lambda x: meshnets.data_processing.data_mappers.make_node_features(x))
>>> loader = torch.utils.data.DataLoader(dataset, collate_fn=meshnets.data_processing.torch_utils.collate_fn, batch_size=2)
>>> for e in loader: print(e.x.shape)

torch.Size([9466, 3])
torch.Size([9886, 3])
torch.Size([4840, 3])

```