### PR TITLE
New dataset map options

### DIFF
--- a/meshnets/modules/lightning_wrapper.py
+++ b/meshnets/modules/lightning_wrapper.py
@@ -84,7 +84,7 @@ class MGNLightningWrapper(pl.LightningModule):
         predictions = self.model(batch)
         # Normalize the labels before computing the loss
         y_norm = self.normalize_labels(batch.y)
-        loss = torch.nn.functional.mse_loss(predictions, y_norm)
+        loss = torch.nn.functional.mse_loss(torch.squeeze(predictions), y_norm)
         return loss
 
     def configure_optimizers(self) -> torch.optim.Adam:

--- a/meshnets/utils/model_training.py
+++ b/meshnets/utils/model_training.py
@@ -2,8 +2,6 @@
 
 The `train_model` method can be called for standard training with a Ray strategy
 or be used for tuning using Ray."""
-from absl import logging
-
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint
 import torch
@@ -82,7 +80,6 @@ def make_dataloader(version,
                                     version=version,
                                     split=split,
                                     download_mode='force_redownload')
-    logging.info('Making undirected edges.')
     dataset = dataset.map(
         lambda x: data_processing.data_mappers.to_undirected(x, 'edges'),
         num_proc=num_proc,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -25,8 +25,6 @@ flags.DEFINE_multi_string(
 # Dataset splits path
 flags.DEFINE_float('train_split', 0.9,
                    'The fraction of the dataset used for traing.')
-flags.DEFINE_float('validation_split', 0.1,
-                   'The fraction of the dataset used for validation.')
 
 # Dataloaders flags
 flags.DEFINE_integer('batch_size', 8, 'The batch size.')
@@ -80,6 +78,7 @@ def main(_):
 
     config = {
         'dataset_version': FLAGS.dataset_version,
+        'train_split': FLAGS.train_split,
         'val_dataset_versions': FLAGS.val_dataset_versions,
         'batch_size': FLAGS.batch_size,
         'latent_size': FLAGS.latent_size,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -57,6 +57,10 @@ flags.DEFINE_integer('num_cpus_per_worker', 24,
                      'The number of cpus for each worker.')
 flags.DEFINE_bool('use_gpu', True, 'Whether to use gpu or not.')
 
+flags.DEFINE_integer('writer_batch_size', 1,
+                     'Rows to write by hugging face on maps.')
+flags.DEFINE_integer('num_proc', 10, 'Number of processes to use.')
+
 flags.DEFINE_integer(
     'num_examples_dataset_stats', 1000,
     'Number of examples in the dataset to use for statistics.')
@@ -87,7 +91,9 @@ def main(_):
         'max_epochs': FLAGS.max_epochs,
         'log_every_n_steps': FLAGS.log_every_n_steps,
         'save_top_k': FLAGS.save_top_k,
-        'num_examples_dataset_stats': FLAGS.num_examples_dataset_stats
+        'num_examples_dataset_stats': FLAGS.num_examples_dataset_stats,
+        'num_proc': FLAGS.num_proc,
+        'writer_batch_size': FLAGS.writer_batch_size
     }
 
     resources_per_worker = {


### PR DESCRIPTION
This pull request adds `num_proc` and `writer_batch_size` to the HuggingFace datasets. Adding `num_proc` ensures the dataset is mapped in parallel. `writer_batch_size` controls the number of examples written to disk at any one point. The default values for `writer_batch_size` where causing memory issues.

It also moves the code to create the dataloaders to a new function to better reuse these instructions.