### PR TITLE
Adding back visualization features

### DIFF
--- a/meshnets/utils/data_visualization.py
+++ b/meshnets/utils/data_visualization.py
@@ -16,13 +16,16 @@ def plot_3d_graph_and_predictions(example,
                                   save_path=None,
                                   figsize=(12, 6)):
     node_positions = example["nodes"]
+    x = [pos[0] for pos in node_positions]
+    y = [pos[1] for pos in node_positions]
+    z = [pos[2] for pos in node_positions]
 
     fig = plt.figure(figsize=figsize)
 
     ax1 = fig.add_subplot(121, projection="3d")
-    ax1.scatter([pos[0] for pos in node_positions],
-                [pos[1] for pos in node_positions],
-                [pos[2] for pos in node_positions],
+    ax1.scatter(x,
+                y,
+                z,
                 c=example["wind_pressures"],
                 cmap=plt.cm.jet,
                 marker="o",
@@ -33,9 +36,9 @@ def plot_3d_graph_and_predictions(example,
     ax1.set_title("Wind Pressures")
 
     ax2 = fig.add_subplot(122, projection="3d")
-    scatter2 = ax2.scatter([pos[0] for pos in node_positions],
-                           [pos[1] for pos in node_positions],
-                           [pos[2] for pos in node_positions],
+    scatter2 = ax2.scatter(x,
+                           y,
+                           z,
                            c=predictions,
                            cmap=plt.cm.jet,
                            marker="o",

--- a/meshnets/utils/model_loading.py
+++ b/meshnets/utils/model_loading.py
@@ -1,8 +1,9 @@
 """Methods for loading models"""
-
 import os
 import tempfile
 from typing import Union
+
+from absl import logging
 
 import mlflow
 # pylint: disable=unused-import
@@ -12,8 +13,11 @@ from meshnets.modules.model import MeshGraphNet
 from meshnets.modules.lightning_wrapper import MGNLightningWrapper
 
 
-def load_model_from_mlflow(tracking_uri: str, run_id: str,
-                           checkpoint: Union[int, str]) -> MGNLightningWrapper:
+def load_model_from_mlflow(
+        tracking_uri: str,
+        run_id: str,
+        checkpoint: Union[int, str],
+        checkpoint_folder: str = 'checkpoints') -> MGNLightningWrapper:
     """Load a model from an MLFlow run and a given checkpoint.
     
     The checkpoint can be specified as either an index or the name of the
@@ -25,16 +29,17 @@ def load_model_from_mlflow(tracking_uri: str, run_id: str,
 
     with tempfile.TemporaryDirectory() as temp_dir:
         if isinstance(checkpoint, int):
-            artifacts = client.list_artifacts(run_id, 'checkpoints')
+            artifacts = client.list_artifacts(run_id, checkpoint_folder)
             checkpoint_path = client.download_artifacts(
                 run_id, path=artifacts[checkpoint].path, dst_path=temp_dir)
         elif isinstance(checkpoint, str):
             checkpoint_path = client.download_artifacts(run_id,
                                                         path=os.path.join(
-                                                            'checkpoints',
+                                                            checkpoint_folder,
                                                             checkpoint),
                                                         dst_path=temp_dir)
 
+        logging.info('Loading checkpoint from %s', checkpoint_path)
         wrapper = MGNLightningWrapper.load_from_checkpoint(checkpoint_path)
 
     return wrapper

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -24,6 +24,9 @@ flags.DEFINE_float("train_split", 0.9,
 flags.DEFINE_string("tracking_uri", None,
                     "The tracking URI for the MLFlow experiments.")
 
+flags.DEFINE_string("checkpoint_folder", "checkpoints",
+                    "The folder to load the checkpoint from in mlflow")
+
 flags.DEFINE_string("run_id", None, "The run id of the experiment to load.")
 
 flags.DEFINE_integer("checkpoint", 0,
@@ -34,6 +37,20 @@ flags.DEFINE_float("point_size", 20, "The size of the points in the plot.")
 flags.DEFINE_string("output_file_path", None, "File path to save the plot.")
 
 flags.mark_flag_as_required("dataset_version")
+
+
+def prepare_example(example):
+    """Prepares the example for visualization."""
+    example = data_mappers.to_undirected(example)
+    example = data_mappers.make_edge_features(example)
+    example = data_mappers.make_node_features(example)
+
+    graph = torch_geometric.data.Data(
+        x=torch.tensor(example["node_features"], dtype=torch.float32),
+        edge_index=torch.tensor(example["edges"]).T,
+        edge_attr=torch.tensor(example["edge_features"], dtype=torch.float32),
+        dtype=torch.float)
+    return example, graph
 
 
 def main(_):
@@ -48,20 +65,13 @@ def main(_):
         split=f"train[-{1 - FLAGS.train_split:.0%}:]",
         download_mode="force_redownload")
     len_dataset = len(dataset)
+
     random_example = dataset[np.random.randint(len_dataset)]
-    random_example = data_mappers.to_undirected(random_example)
-    random_example = data_mappers.make_edge_features(random_example)
-    random_example = data_mappers.make_node_features(random_example)
+    random_example, graph = prepare_example(random_example)
 
     wrapper = model_loading.load_model_from_mlflow(FLAGS.tracking_uri,
                                                    FLAGS.run_id,
                                                    FLAGS.checkpoint)
-    graph = torch_geometric.data.Data(
-        x=torch.tensor(random_example["node_features"], dtype=torch.float32),
-        edge_index=torch.tensor(random_example["edges"]).T,
-        edge_attr=torch.tensor(random_example["edge_features"],
-                               dtype=torch.float32),
-        dtype=torch.float)
 
     with torch.no_grad():
         prediction = wrapper(graph)


### PR DESCRIPTION
This pull request adds back the visualization features lost when migrating to Hugging face Datasets. This new function is completely independent of original mesh files and can work only with the examples in the datasets.

Example outputs for an untrained model:
![image](https://github.com/inductiva/meshnets/assets/33664950/b380fca7-51ba-4edc-94a0-426226fb0b3a)
![image](https://github.com/inductiva/meshnets/assets/33664950/3b04672d-6dac-4629-ace2-1035c2dfb9a7)



