### PR TITLE
More frequent callbacks

### DIFF
--- a/meshnets/utils/callbacks.py
+++ b/meshnets/utils/callbacks.py
@@ -39,13 +39,17 @@ class MLFlowLoggerFinalizeCheckpointer(MLFlowLogger):
         if self._checkpoint_callback is None:
             self._checkpoint_callback = checkpoint_callback
 
+        self.experiment.log_artifacts(self.run_id,
+                                      self._checkpoint_callback.dirpath,
+                                      artifact_path='checkpoints')
+
     def finalize(self, status: str) -> None:
         """Log the checkpoints as MLFlow artifacts at the end of training."""
 
         if self._checkpoint_callback is not None:
             self.experiment.log_artifacts(self.run_id,
                                           self._checkpoint_callback.dirpath,
-                                          artifact_path='checkpoints')
+                                          artifact_path='checkpoints_final')
         super().finalize(status)
 
 


### PR DESCRIPTION
This pull request adds more frequent model logs. At the moment we are only logging the models at the end of training. This has the drawback that, if something goes wrong before the training loops ends, no models are logged to mlflow.

Therefore I am also logging the models at the end of each epoch. At the moment this has the **drawback** that more models will be logged to mlflow causing more memory to be used. However, this is just a quick temporary fix. Very soon I will add a callback that logs just the best model seen during training thus saving memory.

We still log the top three models to mlflow once training ends. Now they are stored under `checkpoints_final`